### PR TITLE
Add prepareUpdateUserSettings WASM binding and fix user settings action JSON format

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ signed = finalize_transaction(prepared, signature)
 | `prepareGroup(orders, options)` | Atomic multi-order (one tx) |
 | `prepareAgentWallet(agent, delete, options)` | Agent wallet authorization |
 | `prepareFaucet(options)` | Testnet faucet request |
+| `prepareUpdateUserSettings(settings, options)` | Update user settings (leverage) |
 
 ### Agent Wallet with External Signing
 

--- a/crates/bulk-keychain-wasm/src/lib.rs
+++ b/crates/bulk-keychain-wasm/src/lib.rs
@@ -5,10 +5,9 @@
 
 use bulk_keychain::{
     finalize_transaction, prepare_agent_wallet, prepare_all, prepare_faucet, prepare_group,
-    prepare_user_settings,
-    prepare_message, Cancel, CancelAll, Hash, Keypair, Modify, NonceManager, NonceStrategy,
-    OraclePrice, Order, OrderItem, OrderType, PreparedMessage, Pubkey, PythOraclePrice, Signer,
-    TimeInForce, UserSettings,
+    prepare_message, prepare_user_settings, Cancel, CancelAll, Hash, Keypair, Modify, NonceManager,
+    NonceStrategy, OraclePrice, Order, OrderItem, OrderType, PreparedMessage, Pubkey,
+    PythOraclePrice, Signer, TimeInForce, UserSettings,
 };
 use serde::Deserialize;
 use wasm_bindgen::prelude::*;

--- a/crates/bulk-keychain-wasm/src/lib.rs
+++ b/crates/bulk-keychain-wasm/src/lib.rs
@@ -5,6 +5,7 @@
 
 use bulk_keychain::{
     finalize_transaction, prepare_agent_wallet, prepare_all, prepare_faucet, prepare_group,
+    prepare_user_settings,
     prepare_message, Cancel, CancelAll, Hash, Keypair, Modify, NonceManager, NonceStrategy,
     OraclePrice, Order, OrderItem, OrderType, PreparedMessage, Pubkey, PythOraclePrice, Signer,
     TimeInForce, UserSettings,
@@ -836,6 +837,35 @@ pub fn wasm_prepare_faucet(options: JsValue) -> Result<WasmPreparedMessage, JsEr
     let nonce = opts.nonce.map(|n| n as u64);
 
     let prepared = prepare_faucet(&account, signer.as_ref(), nonce)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+
+    Ok(WasmPreparedMessage { inner: prepared })
+}
+
+/// Prepare user settings update for external signing
+///
+/// @param settings - { max_leverage: [[symbol, leverage], ...] }
+/// @param options - { account: string, signer?: string, nonce?: number }
+#[wasm_bindgen(js_name = prepareUpdateUserSettings)]
+pub fn wasm_prepare_update_user_settings(
+    settings: JsValue,
+    options: JsValue,
+) -> Result<WasmPreparedMessage, JsError> {
+    let settings_input: UserSettingsInput =
+        serde_wasm_bindgen::from_value(settings).map_err(|e| JsError::new(&e.to_string()))?;
+    let opts: PrepareOptions =
+        serde_wasm_bindgen::from_value(options).map_err(|e| JsError::new(&e.to_string()))?;
+
+    let account = Pubkey::from_base58(&opts.account).map_err(|e| JsError::new(&e.to_string()))?;
+    let signer = opts
+        .signer
+        .map(|s| Pubkey::from_base58(&s))
+        .transpose()
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    let nonce = opts.nonce.map(|n| n as u64);
+
+    let user_settings = UserSettings::new(settings_input.max_leverage);
+    let prepared = prepare_user_settings(user_settings, &account, signer.as_ref(), nonce)
         .map_err(|e| JsError::new(&e.to_string()))?;
 
     Ok(WasmPreparedMessage { inner: prepared })

--- a/crates/bulk-keychain/src/prepare.rs
+++ b/crates/bulk-keychain/src/prepare.rs
@@ -284,12 +284,12 @@ fn action_to_json(action: &Action) -> Result<Vec<serde_json::Value>> {
             }
         })]),
         Action::UpdateUserSettings(settings) => {
-            let entries: Vec<_> = settings
+            let m: serde_json::Map<String, serde_json::Value> = settings
                 .max_leverage
                 .iter()
-                .map(|(symbol, lev)| json!([symbol, lev]))
+                .map(|(symbol, lev)| (symbol.clone(), json!(lev)))
                 .collect();
-            Ok(vec![json!({ "updateUserSettings": { "m": entries } })])
+            Ok(vec![json!({ "updateUserSettings": { "m": m } })])
         }
         Action::Oracle { oracles } => Ok(oracles
             .iter()


### PR DESCRIPTION
- Adds prepareUpdateUserSettings for external wallet signing of user settings updates

- Fixes updateUserSettings action JSON to serialize m as an object ({"SOL-USD": 20}) instead of array tuples ([["SOL-USD", 20]]), matching the backend's expected format