### PR TITLE
Zeroize temporary secret key buffers after use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ categories = ["cryptography", "api-bindings"]
 ed25519-dalek = { version = "2.1", features = ["rand_core", "batch"] }
 sha2 = "0.10"
 rand = "0.8"
+zeroize = { version = "1.8", features = ["derive"] }
 bs58 = "0.5"
 base64 = "0.22"
 hex = "0.4"

--- a/crates/bulk-keychain/Cargo.toml
+++ b/crates/bulk-keychain/Cargo.toml
@@ -12,6 +12,7 @@ categories.workspace = true
 ed25519-dalek = { workspace = true }
 sha2 = { workspace = true }
 rand = { workspace = true }
+zeroize = { workspace = true }
 bs58 = { workspace = true }
 base64 = { workspace = true }
 hex = { workspace = true }

--- a/crates/bulk-keychain/src/keypair.rs
+++ b/crates/bulk-keychain/src/keypair.rs
@@ -3,6 +3,7 @@
 use crate::{Error, Pubkey, Result};
 use ed25519_dalek::{SecretKey, SigningKey, VerifyingKey};
 use rand::rngs::OsRng;
+use zeroize::Zeroize;
 
 /// Ed25519 keypair for signing transactions
 #[derive(Clone)]
@@ -28,6 +29,7 @@ impl Keypair {
         let mut bytes = [0u8; 32];
         bytes.copy_from_slice(secret);
         let signing_key = SigningKey::from_bytes(&bytes);
+        bytes.zeroize();
         Ok(Self { signing_key })
     }
 
@@ -50,10 +52,12 @@ impl Keypair {
 
     /// Create from base58-encoded secret key or keypair
     pub fn from_base58(s: &str) -> Result<Self> {
-        let bytes = bs58::decode(s)
+        let mut bytes = bs58::decode(s)
             .into_vec()
             .map_err(|e| Error::InvalidBase58(e.to_string()))?;
-        Self::from_bytes(&bytes)
+        let result = Self::from_bytes(&bytes);
+        bytes.zeroize();
+        result
     }
 
     /// Get the public key


### PR DESCRIPTION
## Summary

- Adds explicit zeroization of intermediate byte arrays used during keypair construction (`from_secret_key`, `from_base58`) so that secret material does not linger in process memory after being copied into the `SigningKey`.
- While `ed25519-dalek`'s `SigningKey` already implements `ZeroizeOnDrop` for its own internal state, the **temporary buffers** created during deserialization (the `[u8; 32]` stack array and decoded `Vec<u8>`) were previously left untouched after use.
- Introduces `zeroize` 1.8 as a workspace dependency.

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | Add `zeroize` to workspace dependencies |
| `crates/bulk-keychain/Cargo.toml` | Wire up `zeroize` workspace dep |
| `crates/bulk-keychain/src/keypair.rs` | Zeroize temp `[u8; 32]` in `from_secret_key()` and decoded `Vec<u8>` in `from_base58()` |

## Test plan

- [x] All 38 existing unit tests pass (`cargo test -p bulk-keychain`)
- [x] Both doc-tests pass
- [ ] No API changes — fully backwards compatible