### PR TITLE
Remove redundant pubkey computation in parallel signing path

### DIFF
--- a/crates/bulk-keychain/src/sign.rs
+++ b/crates/bulk-keychain/src/sign.rs
@@ -199,7 +199,6 @@ impl Signer {
 
     fn sign_single_item(&self, item: OrderItem, nonce: u64) -> Result<SignedTransaction> {
         let account = self.keypair.pubkey();
-        let signer_pubkey = self.keypair.pubkey();
         let order_id = if self.compute_order_id {
             let mut scratch = Vec::with_capacity(96);
             compute_order_item_id_at_index(&item, 0, nonce, &account, &mut scratch)
@@ -219,7 +218,7 @@ impl Signer {
             actions,
             nonce,
             account: account.to_base58(),
-            signer: signer_pubkey.to_base58(),
+            signer: account.to_base58(),
             signature,
             order_id,
             order_ids: None,
@@ -350,7 +349,6 @@ impl Signer {
         }
 
         let account = self.keypair.pubkey();
-        let signer_pubkey = self.keypair.pubkey();
         let order_id = if self.compute_order_id && orders.len() == 1 {
             let mut scratch = Vec::with_capacity(96);
             compute_order_item_id_at_index(&orders[0], 0, nonce, &account, &mut scratch)
@@ -387,7 +385,7 @@ impl Signer {
             actions,
             nonce,
             account: account.to_base58(),
-            signer: signer_pubkey.to_base58(),
+            signer: account.to_base58(),
             signature,
             order_id,
             order_ids,


### PR DESCRIPTION
## Summary

- `sign_single_item()` and `sign_single_order_batch()` each called `self.keypair.pubkey()` twice per invocation — once for `account` and again for `signer_pubkey`. Both values are always identical in these methods.
- Each `pubkey()` call invokes `SigningKey::verifying_key()`, which performs an Ed25519 scalar-base multiplication. In the `sign_all()` hot path (parallel via Rayon), this redundant computation is executed on every item, doubling the elliptic-curve work per transaction.
- This patch reuses the single `account` variable for both the `account` and `signer` fields in the returned `SignedTransaction`.

## Changes

| File | Change |
|------|--------|
| `crates/bulk-keychain/src/sign.rs` | Remove duplicate `self.keypair.pubkey()` calls in `sign_single_item()` and `sign_single_order_batch()` |

## Test plan

- [x] All 38 existing unit tests pass (`cargo test -p bulk-keychain`)
- [x] Both doc-tests pass
- [ ] No API changes — fully backwards compatible
- [ ] Benchmarks (`cargo bench -p bulk-keychain`) should show improvement on batch signing