### PR TITLE
feat: add conditional order types (stop, take-profit, range, trigger basket)

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,3 +376,57 @@ const signed = prepared.finalize(bs58.encode(signature));
   symbols: ['BTC-USD']  // or [] for all symbols
 }
 ```
+
+### Stop-Loss
+```typescript
+{
+  type: 'stop',
+  symbol: 'BTC-USD',
+  isBuy: false,
+  size: 0.1,
+  triggerPrice: 90000,
+  limitPrice: 89900,  // omit for market-style fill
+}
+```
+
+### Take-Profit
+```typescript
+{
+  type: 'takeProfit',
+  symbol: 'BTC-USD',
+  isBuy: false,
+  size: 0.1,
+  triggerPrice: 110000,
+  limitPrice: 110100,  // omit for market-style fill
+}
+```
+
+### Range / OCO (Stop-Loss + Take-Profit)
+```typescript
+{
+  type: 'range',
+  symbol: 'BTC-USD',
+  isBuy: false,
+  size: 0.1,
+  pmin: 90000,    // stop-loss trigger price
+  pmax: 110000,   // take-profit trigger price
+  lmin: 89900,    // stop-loss limit price (omit for market-style fill)
+  lmax: 110100,   // take-profit limit price (omit for market-style fill)
+}
+```
+
+### Trigger Basket
+Fires a set of child actions when price crosses a threshold. Nested actions may be: `stop`, `takeProfit`, `range`, `order`, `cancel`, `cancelAll`, `modify`.
+
+```typescript
+{
+  type: 'trig',
+  symbol: 'BTC-USD',
+  isBuy: true,
+  triggerPrice: 100000,
+  actions: [
+    { type: 'stop',       symbol: 'BTC-USD', isBuy: false, size: 0.1, triggerPrice: 95000 },
+    { type: 'takeProfit', symbol: 'BTC-USD', isBuy: false, size: 0.1, triggerPrice: 110000 },
+  ],
+}
+```

--- a/crates/bulk-keychain-python/src/lib.rs
+++ b/crates/bulk-keychain-python/src/lib.rs
@@ -557,7 +557,13 @@ fn parse_order_item(obj: &Bound<'_, PyAny>) -> PyResult<OrderItem> {
                 .get_item("limit_price")?
                 .map(|v| v.extract().unwrap_or(f64::NAN))
                 .unwrap_or(f64::NAN);
-            Ok(OrderItem::Stop(Stop { symbol, is_buy, size, trigger_price, limit_price }))
+            Ok(OrderItem::Stop(Stop {
+                symbol,
+                is_buy,
+                size,
+                trigger_price,
+                limit_price,
+            }))
         }
         "take_profit" | "tp" => {
             let symbol: String = dict
@@ -580,7 +586,13 @@ fn parse_order_item(obj: &Bound<'_, PyAny>) -> PyResult<OrderItem> {
                 .get_item("limit_price")?
                 .map(|v| v.extract().unwrap_or(f64::NAN))
                 .unwrap_or(f64::NAN);
-            Ok(OrderItem::TakeProfit(TakeProfit { symbol, is_buy, size, trigger_price, limit_price }))
+            Ok(OrderItem::TakeProfit(TakeProfit {
+                symbol,
+                is_buy,
+                size,
+                trigger_price,
+                limit_price,
+            }))
         }
         "range" | "rng" => {
             let symbol: String = dict
@@ -611,7 +623,15 @@ fn parse_order_item(obj: &Bound<'_, PyAny>) -> PyResult<OrderItem> {
                 .get_item("lmax")?
                 .map(|v| v.extract().unwrap_or(f64::NAN))
                 .unwrap_or(f64::NAN);
-            Ok(OrderItem::RangeOco(RangeOco { symbol, is_buy, size, collar_min, collar_max, limit_min, limit_max }))
+            Ok(OrderItem::RangeOco(RangeOco {
+                symbol,
+                is_buy,
+                size,
+                collar_min,
+                collar_max,
+                limit_min,
+                limit_max,
+            }))
         }
         "trig" => {
             let symbol: String = dict
@@ -632,7 +652,12 @@ fn parse_order_item(obj: &Bound<'_, PyAny>) -> PyResult<OrderItem> {
             let actions_list = raw_actions.downcast::<PyList>()?;
             let actions: PyResult<Vec<OrderItem>> =
                 actions_list.iter().map(|a| parse_order_item(&a)).collect();
-            Ok(OrderItem::TriggerBasket(TriggerBasket { symbol, is_buy, trigger_price, actions: actions? }))
+            Ok(OrderItem::TriggerBasket(TriggerBasket {
+                symbol,
+                is_buy,
+                trigger_price,
+                actions: actions?,
+            }))
         }
         _ => Err(PyValueError::new_err(format!(
             "Invalid item type: {}",

--- a/crates/bulk-keychain-python/src/lib.rs
+++ b/crates/bulk-keychain-python/src/lib.rs
@@ -5,8 +5,8 @@
 use bulk_keychain::{
     compute_order_item_id, prepare_agent_wallet, prepare_all, prepare_faucet, prepare_group,
     prepare_message, Cancel, CancelAll, Hash, Keypair, Modify, NonceManager, NonceStrategy,
-    OraclePrice, Order, OrderItem, OrderType, PreparedMessage, Pubkey, PythOraclePrice, Signer,
-    TimeInForce, UserSettings,
+    OraclePrice, Order, OrderItem, OrderType, PreparedMessage, Pubkey, PythOraclePrice, RangeOco,
+    Signer, Stop, TakeProfit, TimeInForce, TriggerBasket, UserSettings,
 };
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -535,6 +535,104 @@ fn parse_order_item(obj: &Bound<'_, PyAny>) -> PyResult<OrderItem> {
                 .unwrap_or_default();
 
             Ok(OrderItem::CancelAll(CancelAll::for_symbols(symbols)))
+        }
+        "stop" | "st" => {
+            let symbol: String = dict
+                .get_item("symbol")?
+                .ok_or_else(|| PyValueError::new_err("Missing 'symbol'"))?
+                .extract()?;
+            let is_buy: bool = dict
+                .get_item("is_buy")?
+                .ok_or_else(|| PyValueError::new_err("Missing 'is_buy'"))?
+                .extract()?;
+            let size: f64 = dict
+                .get_item("size")?
+                .ok_or_else(|| PyValueError::new_err("Missing 'size'"))?
+                .extract()?;
+            let trigger_price: f64 = dict
+                .get_item("trigger_price")?
+                .ok_or_else(|| PyValueError::new_err("Missing 'trigger_price'"))?
+                .extract()?;
+            let limit_price: f64 = dict
+                .get_item("limit_price")?
+                .map(|v| v.extract().unwrap_or(f64::NAN))
+                .unwrap_or(f64::NAN);
+            Ok(OrderItem::Stop(Stop { symbol, is_buy, size, trigger_price, limit_price }))
+        }
+        "take_profit" | "tp" => {
+            let symbol: String = dict
+                .get_item("symbol")?
+                .ok_or_else(|| PyValueError::new_err("Missing 'symbol'"))?
+                .extract()?;
+            let is_buy: bool = dict
+                .get_item("is_buy")?
+                .ok_or_else(|| PyValueError::new_err("Missing 'is_buy'"))?
+                .extract()?;
+            let size: f64 = dict
+                .get_item("size")?
+                .ok_or_else(|| PyValueError::new_err("Missing 'size'"))?
+                .extract()?;
+            let trigger_price: f64 = dict
+                .get_item("trigger_price")?
+                .ok_or_else(|| PyValueError::new_err("Missing 'trigger_price'"))?
+                .extract()?;
+            let limit_price: f64 = dict
+                .get_item("limit_price")?
+                .map(|v| v.extract().unwrap_or(f64::NAN))
+                .unwrap_or(f64::NAN);
+            Ok(OrderItem::TakeProfit(TakeProfit { symbol, is_buy, size, trigger_price, limit_price }))
+        }
+        "range" | "rng" => {
+            let symbol: String = dict
+                .get_item("symbol")?
+                .ok_or_else(|| PyValueError::new_err("Missing 'symbol'"))?
+                .extract()?;
+            let is_buy: bool = dict
+                .get_item("is_buy")?
+                .ok_or_else(|| PyValueError::new_err("Missing 'is_buy'"))?
+                .extract()?;
+            let size: f64 = dict
+                .get_item("size")?
+                .ok_or_else(|| PyValueError::new_err("Missing 'size'"))?
+                .extract()?;
+            let collar_min: f64 = dict
+                .get_item("pmin")?
+                .ok_or_else(|| PyValueError::new_err("Missing 'pmin'"))?
+                .extract()?;
+            let collar_max: f64 = dict
+                .get_item("pmax")?
+                .ok_or_else(|| PyValueError::new_err("Missing 'pmax'"))?
+                .extract()?;
+            let limit_min: f64 = dict
+                .get_item("lmin")?
+                .map(|v| v.extract().unwrap_or(f64::NAN))
+                .unwrap_or(f64::NAN);
+            let limit_max: f64 = dict
+                .get_item("lmax")?
+                .map(|v| v.extract().unwrap_or(f64::NAN))
+                .unwrap_or(f64::NAN);
+            Ok(OrderItem::RangeOco(RangeOco { symbol, is_buy, size, collar_min, collar_max, limit_min, limit_max }))
+        }
+        "trig" => {
+            let symbol: String = dict
+                .get_item("symbol")?
+                .ok_or_else(|| PyValueError::new_err("Missing 'symbol'"))?
+                .extract()?;
+            let is_buy: bool = dict
+                .get_item("is_buy")?
+                .ok_or_else(|| PyValueError::new_err("Missing 'is_buy'"))?
+                .extract()?;
+            let trigger_price: f64 = dict
+                .get_item("trigger_price")?
+                .ok_or_else(|| PyValueError::new_err("Missing 'trigger_price'"))?
+                .extract()?;
+            let raw_actions = dict
+                .get_item("actions")?
+                .ok_or_else(|| PyValueError::new_err("Missing 'actions'"))?;
+            let actions_list = raw_actions.downcast::<PyList>()?;
+            let actions: PyResult<Vec<OrderItem>> =
+                actions_list.iter().map(|a| parse_order_item(&a)).collect();
+            Ok(OrderItem::TriggerBasket(TriggerBasket { symbol, is_buy, trigger_price, actions: actions? }))
         }
         _ => Err(PyValueError::new_err(format!(
             "Invalid item type: {}",

--- a/crates/bulk-keychain-wasm/src/lib.rs
+++ b/crates/bulk-keychain-wasm/src/lib.rs
@@ -545,15 +545,29 @@ impl TryFrom<OrderInput> for OrderItem {
                 let size = input.size.ok_or("stop.size is required")?;
                 let trigger_price = input.trigger_price.ok_or("stop.triggerPrice is required")?;
                 let limit_price = input.limit_price.unwrap_or(f64::NAN);
-                Ok(OrderItem::Stop(Stop { symbol, is_buy, size, trigger_price, limit_price }))
+                Ok(OrderItem::Stop(Stop {
+                    symbol,
+                    is_buy,
+                    size,
+                    trigger_price,
+                    limit_price,
+                }))
             }
             "takeProfit" | "tp" => {
                 let symbol = input.symbol.ok_or("takeProfit.symbol is required")?;
                 let is_buy = input.is_buy.ok_or("takeProfit.isBuy is required")?;
                 let size = input.size.ok_or("takeProfit.size is required")?;
-                let trigger_price = input.trigger_price.ok_or("takeProfit.triggerPrice is required")?;
+                let trigger_price = input
+                    .trigger_price
+                    .ok_or("takeProfit.triggerPrice is required")?;
                 let limit_price = input.limit_price.unwrap_or(f64::NAN);
-                Ok(OrderItem::TakeProfit(TakeProfit { symbol, is_buy, size, trigger_price, limit_price }))
+                Ok(OrderItem::TakeProfit(TakeProfit {
+                    symbol,
+                    is_buy,
+                    size,
+                    trigger_price,
+                    limit_price,
+                }))
             }
             "range" | "rng" => {
                 let symbol = input.symbol.ok_or("range.symbol is required")?;
@@ -563,7 +577,15 @@ impl TryFrom<OrderInput> for OrderItem {
                 let collar_max = input.pmax.ok_or("range.pmax is required")?;
                 let limit_min = input.lmin.unwrap_or(f64::NAN);
                 let limit_max = input.lmax.unwrap_or(f64::NAN);
-                Ok(OrderItem::RangeOco(RangeOco { symbol, is_buy, size, collar_min, collar_max, limit_min, limit_max }))
+                Ok(OrderItem::RangeOco(RangeOco {
+                    symbol,
+                    is_buy,
+                    size,
+                    collar_min,
+                    collar_max,
+                    limit_min,
+                    limit_max,
+                }))
             }
             "trig" => {
                 let symbol = input.symbol.ok_or("trig.symbol is required")?;
@@ -572,7 +594,12 @@ impl TryFrom<OrderInput> for OrderItem {
                 let raw_actions = input.actions.ok_or("trig.actions is required")?;
                 let actions: Result<Vec<OrderItem>, String> =
                     raw_actions.into_iter().map(|a| a.try_into()).collect();
-                Ok(OrderItem::TriggerBasket(TriggerBasket { symbol, is_buy, trigger_price, actions: actions? }))
+                Ok(OrderItem::TriggerBasket(TriggerBasket {
+                    symbol,
+                    is_buy,
+                    trigger_price,
+                    actions: actions?,
+                }))
             }
             _ => Err(format!("Invalid item type: {}", input.item_type)),
         }

--- a/crates/bulk-keychain-wasm/src/lib.rs
+++ b/crates/bulk-keychain-wasm/src/lib.rs
@@ -7,7 +7,7 @@ use bulk_keychain::{
     finalize_transaction, prepare_agent_wallet, prepare_all, prepare_faucet, prepare_group,
     prepare_message, prepare_user_settings, Cancel, CancelAll, Hash, Keypair, Modify, NonceManager,
     NonceStrategy, OraclePrice, Order, OrderItem, OrderType, PreparedMessage, Pubkey,
-    PythOraclePrice, Signer, TimeInForce, UserSettings,
+    PythOraclePrice, RangeOco, Signer, Stop, TakeProfit, TimeInForce, TriggerBasket, UserSettings,
 };
 use serde::Deserialize;
 use wasm_bindgen::prelude::*;
@@ -423,6 +423,13 @@ struct OrderInput {
     order_id: Option<String>,
     amount: Option<f64>,
     symbols: Option<Vec<String>>,
+    trigger_price: Option<f64>,
+    limit_price: Option<f64>,
+    pmin: Option<f64>,
+    pmax: Option<f64>,
+    lmin: Option<f64>,
+    lmax: Option<f64>,
+    actions: Option<Vec<OrderInput>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -531,6 +538,41 @@ impl TryFrom<OrderInput> for OrderItem {
             "cancelAll" => {
                 let symbols = input.symbols.unwrap_or_default();
                 Ok(OrderItem::CancelAll(CancelAll::for_symbols(symbols)))
+            }
+            "stop" | "st" => {
+                let symbol = input.symbol.ok_or("stop.symbol is required")?;
+                let is_buy = input.is_buy.ok_or("stop.isBuy is required")?;
+                let size = input.size.ok_or("stop.size is required")?;
+                let trigger_price = input.trigger_price.ok_or("stop.triggerPrice is required")?;
+                let limit_price = input.limit_price.unwrap_or(f64::NAN);
+                Ok(OrderItem::Stop(Stop { symbol, is_buy, size, trigger_price, limit_price }))
+            }
+            "takeProfit" | "tp" => {
+                let symbol = input.symbol.ok_or("takeProfit.symbol is required")?;
+                let is_buy = input.is_buy.ok_or("takeProfit.isBuy is required")?;
+                let size = input.size.ok_or("takeProfit.size is required")?;
+                let trigger_price = input.trigger_price.ok_or("takeProfit.triggerPrice is required")?;
+                let limit_price = input.limit_price.unwrap_or(f64::NAN);
+                Ok(OrderItem::TakeProfit(TakeProfit { symbol, is_buy, size, trigger_price, limit_price }))
+            }
+            "range" | "rng" => {
+                let symbol = input.symbol.ok_or("range.symbol is required")?;
+                let is_buy = input.is_buy.ok_or("range.isBuy is required")?;
+                let size = input.size.ok_or("range.size is required")?;
+                let collar_min = input.pmin.ok_or("range.pmin is required")?;
+                let collar_max = input.pmax.ok_or("range.pmax is required")?;
+                let limit_min = input.lmin.unwrap_or(f64::NAN);
+                let limit_max = input.lmax.unwrap_or(f64::NAN);
+                Ok(OrderItem::RangeOco(RangeOco { symbol, is_buy, size, collar_min, collar_max, limit_min, limit_max }))
+            }
+            "trig" => {
+                let symbol = input.symbol.ok_or("trig.symbol is required")?;
+                let is_buy = input.is_buy.ok_or("trig.isBuy is required")?;
+                let trigger_price = input.trigger_price.ok_or("trig.triggerPrice is required")?;
+                let raw_actions = input.actions.ok_or("trig.actions is required")?;
+                let actions: Result<Vec<OrderItem>, String> =
+                    raw_actions.into_iter().map(|a| a.try_into()).collect();
+                Ok(OrderItem::TriggerBasket(TriggerBasket { symbol, is_buy, trigger_price, actions: actions? }))
             }
             _ => Err(format!("Invalid item type: {}", input.item_type)),
         }

--- a/crates/bulk-keychain/src/prepare.rs
+++ b/crates/bulk-keychain/src/prepare.rs
@@ -383,6 +383,46 @@ fn order_item_to_json(item: &OrderItem) -> Result<serde_json::Value> {
                 "c": cancel_all.symbols
             }
         })),
+        OrderItem::Stop(stop) => Ok(json!({
+            "st": {
+                "c": stop.symbol,
+                "d": stop.is_buy,
+                "sz": stop.size,
+                "tr": stop.trigger_price,
+                "lim": stop.limit_price
+            }
+        })),
+        OrderItem::TakeProfit(tp) => Ok(json!({
+            "tp": {
+                "c": tp.symbol,
+                "d": tp.is_buy,
+                "sz": tp.size,
+                "tr": tp.trigger_price,
+                "lim": tp.limit_price
+            }
+        })),
+        OrderItem::RangeOco(rng) => Ok(json!({
+            "rng": {
+                "c": rng.symbol,
+                "d": rng.is_buy,
+                "sz": rng.size,
+                "pmin": rng.collar_min,
+                "pmax": rng.collar_max,
+                "lmin": rng.limit_min,
+                "lmax": rng.limit_max
+            }
+        })),
+        OrderItem::TriggerBasket(trig) => {
+            let nested: Result<Vec<_>> = trig.actions.iter().map(order_item_to_json).collect();
+            Ok(json!({
+                "trig": {
+                    "c": trig.symbol,
+                    "d": trig.is_buy,
+                    "tr": trig.trigger_price,
+                    "a": nested?
+                }
+            }))
+        }
     }
 }
 

--- a/crates/bulk-keychain/src/sdk_compat.rs
+++ b/crates/bulk-keychain/src/sdk_compat.rs
@@ -154,6 +154,64 @@ struct TxPythOracle {
 }
 
 #[derive(Clone, Debug, Serialize)]
+struct TxStop {
+    #[serde(rename = "c")]
+    symbol: String,
+    #[serde(rename = "d")]
+    is_buy: bool,
+    #[serde(rename = "sz", with = "serde_safe_f64")]
+    size: f64,
+    #[serde(rename = "tr", with = "serde_safe_f64")]
+    trigger_price: f64,
+    #[serde(rename = "lim", with = "serde_safe_f64")]
+    limit_price: f64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct TxTakeProfit {
+    #[serde(rename = "c")]
+    symbol: String,
+    #[serde(rename = "d")]
+    is_buy: bool,
+    #[serde(rename = "sz", with = "serde_safe_f64")]
+    size: f64,
+    #[serde(rename = "tr", with = "serde_safe_f64")]
+    trigger_price: f64,
+    #[serde(rename = "lim", with = "serde_safe_f64")]
+    limit_price: f64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct TxRangeOco {
+    #[serde(rename = "c")]
+    symbol: String,
+    #[serde(rename = "d")]
+    is_buy: bool,
+    #[serde(rename = "sz", with = "serde_safe_f64")]
+    size: f64,
+    #[serde(rename = "pmin", with = "serde_safe_f64")]
+    collar_min: f64,
+    #[serde(rename = "pmax", with = "serde_safe_f64")]
+    collar_max: f64,
+    #[serde(rename = "lmin", with = "serde_safe_f64")]
+    limit_min: f64,
+    #[serde(rename = "lmax", with = "serde_safe_f64")]
+    limit_max: f64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct TxTriggerBasket {
+    #[serde(rename = "c")]
+    symbol: String,
+    #[serde(rename = "d")]
+    is_buy: bool,
+    #[serde(rename = "tr", with = "serde_safe_f64")]
+    trigger_price: f64,
+    #[serde(rename = "a")]
+    actions: Vec<TxAction>,
+}
+
+#[derive(Clone, Debug, Serialize)]
 struct TxFaucet {
     #[serde(with = "serde_pubkey", rename = "u")]
     user: Pubkey,
@@ -194,6 +252,14 @@ enum TxAction {
     Cancel(TxCancelOrder),
     #[serde(rename = "cxa")]
     CancelAll(TxCancelAll),
+    #[serde(rename = "st")]
+    Stop(TxStop),
+    #[serde(rename = "tp")]
+    TakeProfit(TxTakeProfit),
+    #[serde(rename = "rng")]
+    RangeOco(TxRangeOco),
+    #[serde(rename = "trig")]
+    TriggerBasket(TxTriggerBasket),
     #[serde(rename = "px")]
     Price(TxPrice),
     #[serde(rename = "o")]
@@ -245,6 +311,42 @@ fn order_item_to_tx_action(item: &OrderItem) -> Result<TxAction> {
         OrderItem::CancelAll(cancel_all) => Ok(TxAction::CancelAll(TxCancelAll {
             symbols: cancel_all.symbols.clone(),
         })),
+        OrderItem::Stop(stop) => Ok(TxAction::Stop(TxStop {
+            symbol: stop.symbol.clone(),
+            is_buy: stop.is_buy,
+            size: stop.size,
+            trigger_price: stop.trigger_price,
+            limit_price: stop.limit_price,
+        })),
+        OrderItem::TakeProfit(tp) => Ok(TxAction::TakeProfit(TxTakeProfit {
+            symbol: tp.symbol.clone(),
+            is_buy: tp.is_buy,
+            size: tp.size,
+            trigger_price: tp.trigger_price,
+            limit_price: tp.limit_price,
+        })),
+        OrderItem::RangeOco(rng) => Ok(TxAction::RangeOco(TxRangeOco {
+            symbol: rng.symbol.clone(),
+            is_buy: rng.is_buy,
+            size: rng.size,
+            collar_min: rng.collar_min,
+            collar_max: rng.collar_max,
+            limit_min: rng.limit_min,
+            limit_max: rng.limit_max,
+        })),
+        OrderItem::TriggerBasket(trig) => {
+            let actions: Result<Vec<TxAction>> = trig
+                .actions
+                .iter()
+                .map(order_item_to_tx_action)
+                .collect();
+            Ok(TxAction::TriggerBasket(TxTriggerBasket {
+                symbol: trig.symbol.clone(),
+                is_buy: trig.is_buy,
+                trigger_price: trig.trigger_price,
+                actions: actions?,
+            }))
+        }
     }
 }
 

--- a/crates/bulk-keychain/src/sdk_compat.rs
+++ b/crates/bulk-keychain/src/sdk_compat.rs
@@ -335,11 +335,8 @@ fn order_item_to_tx_action(item: &OrderItem) -> Result<TxAction> {
             limit_max: rng.limit_max,
         })),
         OrderItem::TriggerBasket(trig) => {
-            let actions: Result<Vec<TxAction>> = trig
-                .actions
-                .iter()
-                .map(order_item_to_tx_action)
-                .collect();
+            let actions: Result<Vec<TxAction>> =
+                trig.actions.iter().map(order_item_to_tx_action).collect();
             Ok(TxAction::TriggerBasket(TxTriggerBasket {
                 symbol: trig.symbol.clone(),
                 is_buy: trig.is_buy,

--- a/crates/bulk-keychain/src/serialize.rs
+++ b/crates/bulk-keychain/src/serialize.rs
@@ -174,6 +174,50 @@ impl WincodeSerializer {
                 }
                 Ok(())
             }
+            OrderItem::Stop(stop) => {
+                // st => discriminant 5
+                self.write_u32(5);
+                self.write_string(&stop.symbol);
+                self.write_bool(stop.is_buy);
+                self.write_f64(stop.size);
+                self.write_f64(stop.trigger_price);
+                self.write_f64(stop.limit_price);
+                Ok(())
+            }
+            OrderItem::TakeProfit(tp) => {
+                // tp => discriminant 6
+                self.write_u32(6);
+                self.write_string(&tp.symbol);
+                self.write_bool(tp.is_buy);
+                self.write_f64(tp.size);
+                self.write_f64(tp.trigger_price);
+                self.write_f64(tp.limit_price);
+                Ok(())
+            }
+            OrderItem::RangeOco(rng) => {
+                // rng => discriminant 7
+                self.write_u32(7);
+                self.write_string(&rng.symbol);
+                self.write_bool(rng.is_buy);
+                self.write_f64(rng.size);
+                self.write_f64(rng.collar_min);
+                self.write_f64(rng.collar_max);
+                self.write_f64(rng.limit_min);
+                self.write_f64(rng.limit_max);
+                Ok(())
+            }
+            OrderItem::TriggerBasket(trig) => {
+                // trig => discriminant 8
+                self.write_u32(8);
+                self.write_string(&trig.symbol);
+                self.write_bool(trig.is_buy);
+                self.write_f64(trig.trigger_price);
+                self.write_u64(trig.actions.len() as u64);
+                for nested in &trig.actions {
+                    self.write_order_item_action(nested)?;
+                }
+                Ok(())
+            }
         }
     }
 

--- a/crates/bulk-keychain/src/sign.rs
+++ b/crates/bulk-keychain/src/sign.rs
@@ -560,6 +560,50 @@ impl Signer {
                     "c": cancel_all.symbols
                 }
             })),
+            OrderItem::Stop(stop) => Ok(json!({
+                "st": {
+                    "c": stop.symbol,
+                    "d": stop.is_buy,
+                    "sz": stop.size,
+                    "tr": stop.trigger_price,
+                    "lim": stop.limit_price
+                }
+            })),
+            OrderItem::TakeProfit(tp) => Ok(json!({
+                "tp": {
+                    "c": tp.symbol,
+                    "d": tp.is_buy,
+                    "sz": tp.size,
+                    "tr": tp.trigger_price,
+                    "lim": tp.limit_price
+                }
+            })),
+            OrderItem::RangeOco(rng) => Ok(json!({
+                "rng": {
+                    "c": rng.symbol,
+                    "d": rng.is_buy,
+                    "sz": rng.size,
+                    "pmin": rng.collar_min,
+                    "pmax": rng.collar_max,
+                    "lmin": rng.limit_min,
+                    "lmax": rng.limit_max
+                }
+            })),
+            OrderItem::TriggerBasket(trig) => {
+                let nested: Result<Vec<_>> = trig
+                    .actions
+                    .iter()
+                    .map(|a| self.order_item_to_json(a))
+                    .collect();
+                Ok(json!({
+                    "trig": {
+                        "c": trig.symbol,
+                        "d": trig.is_buy,
+                        "tr": trig.trigger_price,
+                        "a": nested?
+                    }
+                }))
+            }
         }
     }
 }

--- a/crates/bulk-keychain/src/types.rs
+++ b/crates/bulk-keychain/src/types.rs
@@ -452,13 +452,13 @@ impl OrderItem {
                 OrderType::Limit { .. } => 1,   // l
                 OrderType::Trigger { .. } => 0, // m
             },
-            Self::Modify(_) => 2,         // mod
-            Self::Cancel(_) => 3,         // cx
-            Self::CancelAll(_) => 4,      // cxa
-            Self::Stop(_) => 5,           // st
-            Self::TakeProfit(_) => 6,     // tp
-            Self::RangeOco(_) => 7,       // rng
-            Self::TriggerBasket(_) => 8,  // trig
+            Self::Modify(_) => 2,        // mod
+            Self::Cancel(_) => 3,        // cx
+            Self::CancelAll(_) => 4,     // cxa
+            Self::Stop(_) => 5,          // st
+            Self::TakeProfit(_) => 6,    // tp
+            Self::RangeOco(_) => 7,      // rng
+            Self::TriggerBasket(_) => 8, // trig
         }
     }
 }

--- a/crates/bulk-keychain/src/types.rs
+++ b/crates/bulk-keychain/src/types.rs
@@ -365,10 +365,64 @@ impl CancelAll {
 }
 
 // ============================================================================
+// Conditional order types
+// ============================================================================
+
+/// Stop-loss order: triggers when price crosses threshold
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Stop {
+    pub symbol: String,
+    /// true = buy/long side, false = sell/short side
+    pub is_buy: bool,
+    pub size: f64,
+    pub trigger_price: f64,
+    /// Limit price; NaN means market-style fill
+    pub limit_price: f64,
+}
+
+/// Take-profit order: triggers when price crosses threshold
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TakeProfit {
+    pub symbol: String,
+    /// true = buy/long side, false = sell/short side
+    pub is_buy: bool,
+    pub size: f64,
+    pub trigger_price: f64,
+    /// Limit price; NaN means market-style fill
+    pub limit_price: f64,
+}
+
+/// Range / OCO order: collar around a position
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RangeOco {
+    pub symbol: String,
+    /// true = buy/long collar, false = sell/short collar
+    pub is_buy: bool,
+    pub size: f64,
+    pub collar_min: f64,
+    pub collar_max: f64,
+    /// Limit price for min side; NaN means market-style fill
+    pub limit_min: f64,
+    /// Limit price for max side; NaN means market-style fill
+    pub limit_max: f64,
+}
+
+/// Trigger basket: fires a set of actions when price crosses threshold.
+/// Nested actions may be: m, l, mod, cx, cxa, st, tp, rng.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TriggerBasket {
+    pub symbol: String,
+    /// true = buy/long side, false = sell/short side
+    pub is_buy: bool,
+    pub trigger_price: f64,
+    pub actions: Vec<OrderItem>,
+}
+
+// ============================================================================
 // Order Item (union type)
 // ============================================================================
 
-/// An item in the orders array (can be an order, cancel, or cancel all)
+/// An item in the orders array
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum OrderItem {
@@ -380,6 +434,14 @@ pub enum OrderItem {
     Cancel(Cancel),
     /// Cancel all orders
     CancelAll(CancelAll),
+    /// Stop-loss conditional order
+    Stop(Stop),
+    /// Take-profit conditional order
+    TakeProfit(TakeProfit),
+    /// Range / OCO collar order
+    RangeOco(RangeOco),
+    /// Trigger basket: fires nested actions when price crosses threshold
+    TriggerBasket(TriggerBasket),
 }
 
 impl OrderItem {
@@ -390,9 +452,13 @@ impl OrderItem {
                 OrderType::Limit { .. } => 1,   // l
                 OrderType::Trigger { .. } => 0, // m
             },
-            Self::Modify(_) => 2,    // mod
-            Self::Cancel(_) => 3,    // cx
-            Self::CancelAll(_) => 4, // cxa
+            Self::Modify(_) => 2,         // mod
+            Self::Cancel(_) => 3,         // cx
+            Self::CancelAll(_) => 4,      // cxa
+            Self::Stop(_) => 5,           // st
+            Self::TakeProfit(_) => 6,     // tp
+            Self::RangeOco(_) => 7,       // rng
+            Self::TriggerBasket(_) => 8,  // trig
         }
     }
 }
@@ -418,6 +484,30 @@ impl From<Modify> for OrderItem {
 impl From<CancelAll> for OrderItem {
     fn from(cancel_all: CancelAll) -> Self {
         Self::CancelAll(cancel_all)
+    }
+}
+
+impl From<Stop> for OrderItem {
+    fn from(stop: Stop) -> Self {
+        Self::Stop(stop)
+    }
+}
+
+impl From<TakeProfit> for OrderItem {
+    fn from(tp: TakeProfit) -> Self {
+        Self::TakeProfit(tp)
+    }
+}
+
+impl From<RangeOco> for OrderItem {
+    fn from(rng: RangeOco) -> Self {
+        Self::RangeOco(rng)
+    }
+}
+
+impl From<TriggerBasket> for OrderItem {
+    fn from(trig: TriggerBasket) -> Self {
+        Self::TriggerBasket(trig)
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulk-keychain-monorepo",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "description": "A simple high perf signing lib for BULK txns",
   "scripts": {

--- a/packages/bulk-keychain-node/src/lib.rs
+++ b/packages/bulk-keychain-node/src/lib.rs
@@ -621,38 +621,98 @@ impl TryFrom<OrderInput> for OrderItem {
                 Ok(OrderItem::CancelAll(CancelAll::for_symbols(symbols)))
             }
             "stop" | "st" => {
-                let symbol = input.symbol.ok_or_else(|| Error::from_reason("stop.symbol is required"))?;
-                let is_buy = input.is_buy.ok_or_else(|| Error::from_reason("stop.isBuy is required"))?;
-                let size = input.size.ok_or_else(|| Error::from_reason("stop.size is required"))?;
-                let trigger_price = input.trigger_price.ok_or_else(|| Error::from_reason("stop.triggerPrice is required"))?;
+                let symbol = input
+                    .symbol
+                    .ok_or_else(|| Error::from_reason("stop.symbol is required"))?;
+                let is_buy = input
+                    .is_buy
+                    .ok_or_else(|| Error::from_reason("stop.isBuy is required"))?;
+                let size = input
+                    .size
+                    .ok_or_else(|| Error::from_reason("stop.size is required"))?;
+                let trigger_price = input
+                    .trigger_price
+                    .ok_or_else(|| Error::from_reason("stop.triggerPrice is required"))?;
                 let limit_price = input.limit_price.unwrap_or(f64::NAN);
-                Ok(OrderItem::Stop(Stop { symbol, is_buy, size, trigger_price, limit_price }))
+                Ok(OrderItem::Stop(Stop {
+                    symbol,
+                    is_buy,
+                    size,
+                    trigger_price,
+                    limit_price,
+                }))
             }
             "takeProfit" | "tp" => {
-                let symbol = input.symbol.ok_or_else(|| Error::from_reason("takeProfit.symbol is required"))?;
-                let is_buy = input.is_buy.ok_or_else(|| Error::from_reason("takeProfit.isBuy is required"))?;
-                let size = input.size.ok_or_else(|| Error::from_reason("takeProfit.size is required"))?;
-                let trigger_price = input.trigger_price.ok_or_else(|| Error::from_reason("takeProfit.triggerPrice is required"))?;
+                let symbol = input
+                    .symbol
+                    .ok_or_else(|| Error::from_reason("takeProfit.symbol is required"))?;
+                let is_buy = input
+                    .is_buy
+                    .ok_or_else(|| Error::from_reason("takeProfit.isBuy is required"))?;
+                let size = input
+                    .size
+                    .ok_or_else(|| Error::from_reason("takeProfit.size is required"))?;
+                let trigger_price = input
+                    .trigger_price
+                    .ok_or_else(|| Error::from_reason("takeProfit.triggerPrice is required"))?;
                 let limit_price = input.limit_price.unwrap_or(f64::NAN);
-                Ok(OrderItem::TakeProfit(TakeProfit { symbol, is_buy, size, trigger_price, limit_price }))
+                Ok(OrderItem::TakeProfit(TakeProfit {
+                    symbol,
+                    is_buy,
+                    size,
+                    trigger_price,
+                    limit_price,
+                }))
             }
             "range" | "rng" => {
-                let symbol = input.symbol.ok_or_else(|| Error::from_reason("range.symbol is required"))?;
-                let is_buy = input.is_buy.ok_or_else(|| Error::from_reason("range.isBuy is required"))?;
-                let size = input.size.ok_or_else(|| Error::from_reason("range.size is required"))?;
-                let collar_min = input.pmin.ok_or_else(|| Error::from_reason("range.pmin is required"))?;
-                let collar_max = input.pmax.ok_or_else(|| Error::from_reason("range.pmax is required"))?;
+                let symbol = input
+                    .symbol
+                    .ok_or_else(|| Error::from_reason("range.symbol is required"))?;
+                let is_buy = input
+                    .is_buy
+                    .ok_or_else(|| Error::from_reason("range.isBuy is required"))?;
+                let size = input
+                    .size
+                    .ok_or_else(|| Error::from_reason("range.size is required"))?;
+                let collar_min = input
+                    .pmin
+                    .ok_or_else(|| Error::from_reason("range.pmin is required"))?;
+                let collar_max = input
+                    .pmax
+                    .ok_or_else(|| Error::from_reason("range.pmax is required"))?;
                 let limit_min = input.lmin.unwrap_or(f64::NAN);
                 let limit_max = input.lmax.unwrap_or(f64::NAN);
-                Ok(OrderItem::RangeOco(RangeOco { symbol, is_buy, size, collar_min, collar_max, limit_min, limit_max }))
+                Ok(OrderItem::RangeOco(RangeOco {
+                    symbol,
+                    is_buy,
+                    size,
+                    collar_min,
+                    collar_max,
+                    limit_min,
+                    limit_max,
+                }))
             }
             "trig" => {
-                let symbol = input.symbol.ok_or_else(|| Error::from_reason("trig.symbol is required"))?;
-                let is_buy = input.is_buy.ok_or_else(|| Error::from_reason("trig.isBuy is required"))?;
-                let trigger_price = input.trigger_price.ok_or_else(|| Error::from_reason("trig.triggerPrice is required"))?;
-                let raw_actions = input.actions.ok_or_else(|| Error::from_reason("trig.actions is required"))?;
-                let actions: Result<Vec<OrderItem>> = raw_actions.into_iter().map(|a| a.try_into()).collect();
-                Ok(OrderItem::TriggerBasket(TriggerBasket { symbol, is_buy, trigger_price, actions: actions? }))
+                let symbol = input
+                    .symbol
+                    .ok_or_else(|| Error::from_reason("trig.symbol is required"))?;
+                let is_buy = input
+                    .is_buy
+                    .ok_or_else(|| Error::from_reason("trig.isBuy is required"))?;
+                let trigger_price = input
+                    .trigger_price
+                    .ok_or_else(|| Error::from_reason("trig.triggerPrice is required"))?;
+                let raw_actions = input
+                    .actions
+                    .ok_or_else(|| Error::from_reason("trig.actions is required"))?;
+                let actions: Result<Vec<OrderItem>> =
+                    raw_actions.into_iter().map(|a| a.try_into()).collect();
+                Ok(OrderItem::TriggerBasket(TriggerBasket {
+                    symbol,
+                    is_buy,
+                    trigger_price,
+                    actions: actions?,
+                }))
             }
             _ => Err(Error::from_reason(format!(
                 "Invalid item type: {}",

--- a/packages/bulk-keychain-node/src/lib.rs
+++ b/packages/bulk-keychain-node/src/lib.rs
@@ -6,7 +6,8 @@
 use bulk_keychain::{
     prepare_agent_wallet, prepare_all, prepare_faucet, prepare_group, prepare_message, Cancel,
     CancelAll, Hash, Keypair, Modify, NonceManager, NonceStrategy, OraclePrice, Order, OrderItem,
-    OrderType, PreparedMessage, Pubkey, PythOraclePrice, Signer, TimeInForce, UserSettings,
+    OrderType, PreparedMessage, Pubkey, PythOraclePrice, RangeOco, Signer, Stop, TakeProfit,
+    TimeInForce, TriggerBasket, UserSettings,
 };
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -439,6 +440,13 @@ pub struct OrderInput {
     pub order_id: Option<String>,
     pub amount: Option<f64>,
     pub symbols: Option<Vec<String>>,
+    pub trigger_price: Option<f64>,
+    pub limit_price: Option<f64>,
+    pub pmin: Option<f64>,
+    pub pmax: Option<f64>,
+    pub lmin: Option<f64>,
+    pub lmax: Option<f64>,
+    pub actions: Option<Vec<OrderInput>>,
 }
 
 #[napi(object)]
@@ -611,6 +619,40 @@ impl TryFrom<OrderInput> for OrderItem {
             "cancelAll" => {
                 let symbols = input.symbols.unwrap_or_default();
                 Ok(OrderItem::CancelAll(CancelAll::for_symbols(symbols)))
+            }
+            "stop" | "st" => {
+                let symbol = input.symbol.ok_or_else(|| Error::from_reason("stop.symbol is required"))?;
+                let is_buy = input.is_buy.ok_or_else(|| Error::from_reason("stop.isBuy is required"))?;
+                let size = input.size.ok_or_else(|| Error::from_reason("stop.size is required"))?;
+                let trigger_price = input.trigger_price.ok_or_else(|| Error::from_reason("stop.triggerPrice is required"))?;
+                let limit_price = input.limit_price.unwrap_or(f64::NAN);
+                Ok(OrderItem::Stop(Stop { symbol, is_buy, size, trigger_price, limit_price }))
+            }
+            "takeProfit" | "tp" => {
+                let symbol = input.symbol.ok_or_else(|| Error::from_reason("takeProfit.symbol is required"))?;
+                let is_buy = input.is_buy.ok_or_else(|| Error::from_reason("takeProfit.isBuy is required"))?;
+                let size = input.size.ok_or_else(|| Error::from_reason("takeProfit.size is required"))?;
+                let trigger_price = input.trigger_price.ok_or_else(|| Error::from_reason("takeProfit.triggerPrice is required"))?;
+                let limit_price = input.limit_price.unwrap_or(f64::NAN);
+                Ok(OrderItem::TakeProfit(TakeProfit { symbol, is_buy, size, trigger_price, limit_price }))
+            }
+            "range" | "rng" => {
+                let symbol = input.symbol.ok_or_else(|| Error::from_reason("range.symbol is required"))?;
+                let is_buy = input.is_buy.ok_or_else(|| Error::from_reason("range.isBuy is required"))?;
+                let size = input.size.ok_or_else(|| Error::from_reason("range.size is required"))?;
+                let collar_min = input.pmin.ok_or_else(|| Error::from_reason("range.pmin is required"))?;
+                let collar_max = input.pmax.ok_or_else(|| Error::from_reason("range.pmax is required"))?;
+                let limit_min = input.lmin.unwrap_or(f64::NAN);
+                let limit_max = input.lmax.unwrap_or(f64::NAN);
+                Ok(OrderItem::RangeOco(RangeOco { symbol, is_buy, size, collar_min, collar_max, limit_min, limit_max }))
+            }
+            "trig" => {
+                let symbol = input.symbol.ok_or_else(|| Error::from_reason("trig.symbol is required"))?;
+                let is_buy = input.is_buy.ok_or_else(|| Error::from_reason("trig.isBuy is required"))?;
+                let trigger_price = input.trigger_price.ok_or_else(|| Error::from_reason("trig.triggerPrice is required"))?;
+                let raw_actions = input.actions.ok_or_else(|| Error::from_reason("trig.actions is required"))?;
+                let actions: Result<Vec<OrderItem>> = raw_actions.into_iter().map(|a| a.try_into()).collect();
+                Ok(OrderItem::TriggerBasket(TriggerBasket { symbol, is_buy, trigger_price, actions: actions? }))
             }
             _ => Err(Error::from_reason(format!(
                 "Invalid item type: {}",


### PR DESCRIPTION
Adds Stop, TakeProfit, RangeOco, and TriggerBasket as OrderItem variants

- Binary serialization (discriminants 5-8)
- SDK compat + JSON output with correct wire keys (st, tp, rng, trig)
- Input parsing for WASM, Node.js, and Python
- README updated with examples and output shape reference