### PR TITLE
fix: reorder TxAction enum to match sdk discriminant layout

### DIFF
--- a/crates/bulk-keychain/src/sdk_compat.rs
+++ b/crates/bulk-keychain/src/sdk_compat.rs
@@ -284,18 +284,22 @@ enum TxAction {
     RangeOco(TxRangeOco),
     #[serde(rename = "trig")]
     TriggerBasket(TxTriggerBasket),
-    #[serde(rename = "of")]
-    OnFill(TxOnFill),
     #[serde(rename = "trl")]
     TrailingStop(TxTrailingStop),
+    #[serde(rename = "of")]
+    OnFill(TxOnFill),
     #[serde(rename = "px")]
     Price(TxPrice),
     #[serde(rename = "o")]
     PythOracle(TxPythOracle),
+    WhitelistFaucet(TxWhitelistFaucet),
+    #[allow(dead_code)]
+    Reserved14,
+    #[allow(dead_code)]
+    Reserved15,
     Faucet(TxFaucet),
     AgentWalletCreation(TxAgentWalletCreation),
     UpdateUserSettings(TxUpdateUserSettings),
-    WhitelistFaucet(TxWhitelistFaucet),
 }
 
 #[inline]


### PR DESCRIPTION
Swap OnFill/TrailingStop discriminants and reposition Faucet/AgentWallet/UpdateUserSettings to match sdk's expected bincode enum indices