### PR TITLE
fix(ci): include index.js / index.d.ts in npm publish tarball

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,13 @@ jobs:
         working-directory: packages/bulk-keychain-node
         run: node -e "const { NativeKeypair } = require('.'); console.log('OK:', new NativeKeypair().pubkey)"
 
+      - name: Verify npm pack includes JS entrypoints
+        working-directory: packages/bulk-keychain-node
+        run: |
+          npm pack --dry-run 2>&1 | tee /tmp/npm-pack-dry-run.log
+          grep -q 'index.js' /tmp/npm-pack-dry-run.log || { echo 'npm pack missing index.js'; exit 1; }
+          grep -q 'index.d.ts' /tmp/npm-pack-dry-run.log || { echo 'npm pack missing index.d.ts'; exit 1; }
+
   build-python:
     name: Build Python
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,6 +347,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -366,13 +374,28 @@ jobs:
       - name: List artifacts
         run: ls -la packages/bulk-keychain-node/artifacts/
 
-      - name: Move artifacts to package root
-        working-directory: packages/bulk-keychain-node
-        run: mv artifacts/*.node . || true
-
       - name: Install dependencies
         working-directory: packages/bulk-keychain-node
         run: pnpm install --ignore-scripts
+
+      # index.js / index.d.ts are NAPI-RS build outputs and are not committed to git.
+      # Without this step, npm publish packs only package.json + *.node and consumers get MODULE_NOT_FOUND for index.js.
+      - name: Generate JS bindings (index.js, index.d.ts)
+        working-directory: packages/bulk-keychain-node
+        run: pnpm build --target x86_64-unknown-linux-gnu
+
+      - name: Overlay cross-platform .node binaries from CI matrix
+        working-directory: packages/bulk-keychain-node
+        run: mv artifacts/*.node . || true
+
+      - name: Verify npm tarball includes entrypoints
+        working-directory: packages/bulk-keychain-node
+        run: |
+          npm pack --pack-destination /tmp
+          TAR=$(ls -1 /tmp/bulk-keychain-*.tgz | tail -1)
+          tar -tzf "$TAR" | tee /tmp/npm-pack-list.txt
+          grep -q 'package/index.js' /tmp/npm-pack-list.txt || { echo 'missing index.js in npm pack'; exit 1; }
+          grep -q 'package/index.d.ts' /tmp/npm-pack-list.txt || { echo 'missing index.d.ts in npm pack'; exit 1; }
 
       - name: Publish to npm
         if: ${{ !inputs.dry_run }}


### PR DESCRIPTION
## Summary

- **`publish-npm` did not run `pnpm build`**, so `index.js` and `index.d.ts` (NAPI-RS outputs) were never created on the publish runner. The job only copied `*.node` artifacts and ran `npm publish`, which produced tarballs missing the `main` / `types` entrypoints (`MODULE_NOT_FOUND` for consumers).
- **Fix:** install Rust on the publish job, `pnpm install --ignore-scripts`, `pnpm build --target x86_64-unknown-linux-gnu` to emit JS/TS bindings, then overlay all matrix-built `*.node` files before `npm publish`.
- **Guard:** `npm pack` verification step on the publish job; **`npm pack --dry-run` check in CI** so regressions are caught on every PR.

Closes #13

## Verification

- Local: `pnpm build` in `packages/bulk-keychain-node` then `npm pack --dry-run` lists `index.js` and `index.d.ts`.
- Registry (before fix): `npm pack bulk-keychain@0.1.15` contained only `package.json` + `*.node`.


Made with [Cursor](https://cursor.com)